### PR TITLE
Add the option to create and fill an AWS secrets manager secret

### DIFF
--- a/client.mjs
+++ b/client.mjs
@@ -1,0 +1,44 @@
+import { SecretsManagerClient, PutSecretValueCommand, DeleteSecretCommand } from "@aws-sdk/client-secrets-manager";
+import { SSMClient, PutParameterCommand, DeleteParameterCommand } from "@aws-sdk/client-ssm";
+
+export class Client {
+  constructor(useSecretsManager) {
+    this.client = useSecretsManager ? new SecretsManagerClient({}) : new SSMClient({});
+    this.useSecretsManager = useSecretsManager;
+  }
+
+  async create(name, value) {
+    const ssmCommand = new PutParameterCommand({
+      Name: name,
+      Value: value,
+      Type: 'SecureString',
+    });
+    const secretsManagerCommand = new PutSecretValueCommand({
+      SecretId: name,
+      SecretString: value
+    });
+    const command = this.useSecretsManager ? secretsManagerCommand : ssmCommand;
+    try {
+      const response = await this.client.send(command);
+      console.log("Secret created:", response);
+      return response;
+    } catch (error) {
+      console.error("Error creating secret:", error);
+      throw error;
+    }
+  }
+
+  async delete(name) {
+    const ssmCommand = new DeleteParameterCommand({Name: name});
+    const secretsManagerCommand = new DeleteSecretCommand({SecretId: name});
+    const command = this.useSecretsManager ? secretsManagerCommand : ssmCommand;
+    try {
+      const response = await this.client.send(command);
+      console.log("Secret deleted:", response);
+      return response;
+    } catch (error) {
+      console.error("Error deleting secret:", error);
+      throw error;
+    }
+  }
+}

--- a/index.mjs
+++ b/index.mjs
@@ -1,0 +1,17 @@
+import {generate, cleanup} from "./code.mjs";
+import {Client} from "./client.mjs"
+
+export const handler = async (event) => {
+	const parameterName = process.env.PARAMETER_NAME;
+  const useSecretsManager = ['true', '1'].includes(process.env.USE_SECRETS_MANAGER)
+	const client = new Client(useSecretsManager);
+	if (event.tf.action === "delete") {
+		await client.delete(parameterName);
+		await cleanup();
+	}
+	if (event.tf.action === "create") {
+		const {value, outputs} = await generate();
+		await client.create(parameterName, value);
+		return outputs;
+	}
+}

--- a/main.tf
+++ b/main.tf
@@ -45,11 +45,15 @@ resource "aws_lambda_function" "generate_value" {
     # so that the delete permission is still there during destroy
     aws_iam_role_policy.generate_value,
   ]
+
+  tags = var.common_tags
 }
 
 resource "aws_secretsmanager_secret" "secret" {
   count = var.use_secrets_manager ? 1 : 0
-  name = var.parameter_name
+  name  = var.parameter_name
+
+  tags = var.common_tags
 }
 
 resource "aws_lambda_invocation" "generate_value" {
@@ -68,6 +72,8 @@ resource "aws_lambda_invocation" "generate_value" {
 resource "aws_cloudwatch_log_group" "generate_value" {
   name              = "/aws/lambda/${aws_lambda_function.generate_value.function_name}"
   retention_in_days = 14
+
+  tags = var.common_tags
 }
 
 data "aws_iam_policy_document" "logs" {
@@ -84,26 +90,26 @@ data "aws_iam_policy_document" "logs" {
 }
 
 data "aws_iam_policy_document" "ssm" {
-statement {
-  actions = [
-    "ssm:PutParameter",
-    "ssm:DeleteParameter",
-  ]
+  statement {
+    actions = [
+      "ssm:PutParameter",
+      "ssm:DeleteParameter",
+    ]
 
-  resources = [
-    local.parameterArn
-  ]
+    resources = [
+      local.parameterArn
+    ]
   }
 }
 
 data "aws_iam_policy_document" "secrets_manager" {
   statement {
-  actions = [
-    "secretsmanager:DeleteSecret",
-    "secretsmanager:PutSecretValue",
-  ]
+    actions = [
+      "secretsmanager:DeleteSecret",
+      "secretsmanager:PutSecretValue",
+    ]
 
-  resources = [
+    resources = [
       try(aws_secretsmanager_secret.secret[0].arn, null)
     ]
   }
@@ -136,5 +142,5 @@ resource "aws_iam_role" "generate_value_exec" {
   ]
 }
 EOF
+  tags               = var.common_tags
 }
-

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,14 +1,14 @@
 output "parameter_arn" {
-  value = local.parameterArn
-	description = "The ARN of the created SSM parameter"
+  value       = local.parameterArn
+  description = "The ARN of the created SSM parameter"
 }
 
 output "parameter_name" {
-  value = var.parameter_name
-	description = "The name of the created SSM parameter"
+  value       = var.parameter_name
+  description = "The name of the created SSM parameter"
 }
 
 output "outputs" {
-  value = aws_lambda_invocation.generate_value.result
-	description = "The values the generate function return in the output in JSON-encoded form"
+  value       = aws_lambda_invocation.generate_value.result
+  description = "The values the generate function return in the output in JSON-encoded form"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,15 +1,21 @@
 variable "parameter_name" {
-  type = string
-	description = "The SSM parameter's name"
+  type        = string
+  description = "The SSM parameter's name"
 }
 
 variable "code" {
-  type = string
-	description = "A Javascript source that exports a generate() and a cleanup() function"
+  type        = string
+  description = "A Javascript source that exports a generate() and a cleanup() function"
 }
 
 variable "extra_statements" {
-	type = list(any)
-	default = []
-	description = "JSON statements that will be attached to the function's role"
+  type        = list(any)
+  default     = []
+  description = "JSON statements that will be attached to the function's role"
+}
+
+variable "use_secrets_manager" {
+  type        = bool
+  default     = false
+  description = "Will use secrets manager instead of SSM"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -19,3 +19,9 @@ variable "use_secrets_manager" {
   default     = false
   description = "Will use secrets manager instead of SSM"
 }
+
+variable "common_tags" {
+  type        = map(string)
+  default     = {}
+  description = "Tags to set on the resources"
+}


### PR DESCRIPTION
Hi there,

First of all thanks for putting this module out there, it's saved me a bunch of time
We're gonna start using it at [Factorial](https://github.com/factorialco/) to generate keypairs used in signed requests to Cloudfront, but keeping their private key out of the state

But instead of SSM, we're using Secrets Manager and we don't plan to switch

So, while forking the module, I noticed that the actual changes needed were very minimal and that maybe you'd be open to merge them in. If that's not the case, I understand and I'm happy to keep using my own fork

To work on the js modules, I moved them to their own files as it made touching the code easier (it actually showed me right away that the `node:crypto` and `node:util` deps were not needed). So I checked that change in too

WDYT?

Cheers
